### PR TITLE
Update rails_admin_quiztron_import.gemspec

### DIFF
--- a/rails_admin_quiztron_import.gemspec
+++ b/rails_admin_quiztron_import.gemspec
@@ -14,5 +14,4 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'README.rdoc']
 
-  s.add_dependency 'rails', '~> 4.0'
 end


### PR DESCRIPTION
This isn't rails version specific, and the dependency on rails is in the name. 

-> This will make it easier to upgrade to Rails 4.2